### PR TITLE
Created a similar version of the bv-ruby image based on buster

### DIFF
--- a/2.4/jemalloc/buster/Dockerfile
+++ b/2.4/jemalloc/buster/Dockerfile
@@ -1,0 +1,79 @@
+FROM buildpack-deps:buster
+MAINTAINER Patrick Tulskie <patrick@beenverified.com>
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+  && { \
+    echo 'install: --no-document'; \
+    echo 'update: --no-document'; \
+  } >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.4
+ENV RUBY_VERSION 2.4.7
+ENV RUBY_DOWNLOAD_SHA256 a249193c7e79b891a4783f951cad8160fa5fe985c385b4628db8e9913bff1f98
+ENV RUBYGEMS_VERSION 3.0.3
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+  \
+  && buildDeps=' \
+    bison \
+    dpkg-dev \
+    libgdbm-dev \
+    ruby \
+  ' \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $buildDeps libjemalloc-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  \
+  && wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+  && echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+  \
+  && mkdir -p /usr/src/ruby \
+  && tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+  && rm ruby.tar.xz \
+  \
+  && cd /usr/src/ruby \
+  \
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+  && { \
+    echo '#define ENABLE_PATH_CHECK 0'; \
+    echo; \
+    cat file.c; \
+  } > file.c.new \
+  && mv file.c.new file.c \
+  \
+  && autoconf \
+  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+  && ./configure \
+    --build="$gnuArch" \
+    --disable-install-doc \
+    --enable-shared \
+    --with-jemalloc \
+  && make -j "$(nproc)" \
+  && make install \
+  \
+  && apt-get purge -y --auto-remove $buildDeps \
+  && cd / \
+  && rm -r /usr/src/ruby \
+# make sure bundled "rubygems" is older than RUBYGEMS_VERSION (https://github.com/docker-library/ruby/issues/246)
+  && ruby -e 'exit(Gem::Version.create(ENV["RUBYGEMS_VERSION"]) > Gem::Version.create(Gem::VERSION))' \
+  && gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ \
+# rough smoke test
+  && ruby --version && gem --version && bundle --version
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+  BUNDLE_SILENCE_ROOT_WARNING=1 \
+  BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]


### PR DESCRIPTION
This is meant to be a new parallel image to the beenverifiedinc/ruby:2.4.5-stretch-jemalloc image.   This way we can have both on dockerhub and migrate the other images to be based on the beenverifiedinc/ruby:2.4.5-buster-jemalloc image individually.   Everything in this file is the same as the current stretch Dockerfile, with the exception of the FROM line which was switched to buildpack-deps:buster 